### PR TITLE
Add: post router and getPosts endpoint

### DIFF
--- a/packages/api/src/root.ts
+++ b/packages/api/src/root.ts
@@ -1,8 +1,10 @@
 import { developerRouter } from "./router/developer";
+import { postRouter } from "./router/post";
 import { createTRPCRouter } from "./trpc";
 
 export const appRouter = createTRPCRouter({
   developer: developerRouter,
+  post: postRouter,
 });
 
 // export type definition of API

--- a/packages/api/src/router/post.ts
+++ b/packages/api/src/router/post.ts
@@ -1,0 +1,9 @@
+import { createTRPCRouter, publicProcedure } from "../trpc";
+
+export const postRouter = createTRPCRouter({
+  getPosts: publicProcedure.query(async ({ ctx }) => {
+    return await ctx.db.post.findMany({
+      orderBy: { createdAt: "desc" },
+    });
+  }),
+});

--- a/packages/api/src/router/post.ts
+++ b/packages/api/src/router/post.ts
@@ -1,7 +1,7 @@
-import { createTRPCRouter, publicProcedure } from "../trpc";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const postRouter = createTRPCRouter({
-  getPosts: publicProcedure.query(async ({ ctx }) => {
+  getPosts: protectedProcedure.query(async ({ ctx }) => {
     return await ctx.db.post.findMany({
       orderBy: { createdAt: "desc" },
     });


### PR DESCRIPTION
### Description
Adds the `post` router to API and `getPosts` query endpoint.

### Reason for Change
Completes CFD-21

### Type of change
<!--- Please delete options that are not relevant. --->
- [x] New feature (non-breaking change which adds functionality)

### Testing
Given these rows in the database:
<img width="540" alt="image" src="https://github.com/uoftblueprint/centre-for-dreams/assets/40612523/8dbf3cc7-48f1-415b-95aa-aaa923049c02">

`curl http://localhost:3000/api/trpc/post.getPosts` returns

```json
{
  "result": {
    "data": {
      "json": [
        {
          "id": 3,
          "title": "test post",
          "contents": "asdf",
          "createdAt": "2023-10-19T22:01:55.057Z"
        },
        {
          "id": 2,
          "title": "hello world",
          "contents": "lorem ipsum",
          "createdAt": "2023-10-19T04:59:20.060Z"
        },
        {
          "id": 1,
          "title": "first post",
          "contents": "hello",
          "createdAt": "2023-10-19T04:54:20.060Z"
        }
      ],
      "meta": {
        "values": {
          "0.createdAt": [
            "Date"
          ],
          "1.createdAt": [
            "Date"
          ],
          "2.createdAt": [
            "Date"
          ]
        }
      }
    }
  }
}
```
