### PR TITLE
Fix Netlify Ignore Command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  ignore = "pnpm dlx turbo-ignore nextjs"
+  ignore = "npx turbo-ignore nextjs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  ignore = "npx turbo-ignore nextjs"
+  ignore = "npx --yes turbo-ignore nextjs"


### PR DESCRIPTION
### Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. --->
Uses `npx` instead of `pnpm dlx` for the Netlify Ignore command.

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->
Netlify does not have `pnpm` installed when the ignore command is run.

### Type of change
<!--- Please delete options that are not relevant. --->
- [x] CD