### PR TITLE
Add CI check for Expo packages validity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
 
       - name: Check workspaces
         run: pnpm manypkg check
+
+      - name: Check Expo dependencies
+        run: (cd apps/expo && pnpm lint:expo)
   format:
     runs-on: ubuntu-latest
 

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -8,7 +8,8 @@
     "dev": "expo start",
     "dev:android": "expo start --android",
     "dev:ios": "expo start --ios",
-    "lint": "eslint . && npx expo-doctor",
+    "lint": "eslint .",
+    "lint:expo": "expo-doctor",
     "format": "prettier --check \"**/*.{js,cjs,mjs,ts,tsx,md,json}\"",
     "typecheck": "tsc --noEmit",
     "android": "expo run:android",
@@ -48,6 +49,7 @@
     "@types/babel__core": "^7.20.2",
     "@types/react": "^18.2.25",
     "eslint": "^8.50.0",
+    "expo-doctor": "^1.1.3",
     "prettier": "^3.0.3",
     "tailwindcss": "3.3.3",
     "typescript": "^5.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       eslint:
         specifier: ^8.50.0
         version: 8.50.0
+      expo-doctor:
+        specifier: ^1.1.3
+        version: 1.1.3
       prettier:
         specifier: ^3.0.3
         version: 3.0.3
@@ -5216,6 +5219,12 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /expo-doctor@1.1.3:
+    resolution: {integrity: sha512-uJzQB0ZLnBH3SwD8eOST77eNVqsksulujAyQ8A7jQszIwlP0pKAgV5scxyaKmjqKlJQHULvbIVEqrs4ZJUvdRw==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+    hasBin: true
+    dev: true
 
   /expo-file-system@15.4.4(expo@49.0.13):
     resolution: {integrity: sha512-F0xS88D85F7qVQ61r0qBnzh6VW/s6iIl+VaQEEi2nAIOQHw1JIEj4yCXPLTtbyn5VmArbe2dSL3KYz1V+BLkKA==}


### PR DESCRIPTION
### Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. --->
Moves `expo-doctor` check from `pnpm lint` to a separate check.

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->
Helps with caching the results of eslint
