### PR TITLE
Prevent Nextjs upgrades

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,5 +13,6 @@
       "matchCurrentVersion": "!/^0/",
       "automerge": true
     }
-  ]
+  ],
+  "ignoreDeps": ["next"]
 }


### PR DESCRIPTION
### Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. --->
Adds `next` to "ignoreDeps" for Renovate

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->
We don't want to update Next until Netlify can support a version above 13.4
