### PR TITLE
Remove expo monorepo preset from recommended config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "ignorePresets": ["group:expoMonorepo"],
   "packageRules": [
     {
       "matchPackagePatterns": ["^@cfd/"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-   ":dependencyDashboard",
-    ":semanticPrefixFixDepsChoreOthers",
-    ":ignoreModulesAndTests",
-    "group:recommended",
-    "replacements:all",
-    "workarounds:all" 
+    "config:recommended"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Reverts uoftblueprint/centre-for-dreams#53

Adds `group:expoMonorepo` to `ignorePresets`. Pls work 🙏  