### PR TITLE
Renovate bump dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,5 +15,6 @@
       "automerge": true
     }
   ],
-  "ignoreDeps": ["next"]
+  "ignoreDeps": ["next"],
+  "rangeStrategy": "bump"
 }


### PR DESCRIPTION
### Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. --->
Changes range strategy to `bump` instead of `auto`.

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->
Renovate does not support `pnpm` lockfiles, so bump is required to update certain dependencies.
