### PR TITLE
Add Minimum Release Age for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,5 +16,6 @@
     }
   ],
   "ignoreDeps": ["next"],
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "minimumReleaseAge": "5 days"
 }


### PR DESCRIPTION
### Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. --->
Adds minimum release age for Renovate, so dependencies won't be updated until the update is 5 days old.

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->
Want to make sure that updates work

