### PR TITLE
Fix ignored mobile builds on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,14 +106,24 @@ jobs:
     - name: Check for changes to Expo app
       id: check-expo
       run: |
-        if git diff --quiet origin/main HEAD -- apps/expo; then
-          echo "Expo project not modified"
-          echo "skip_job=true" >> $GITHUB_OUTPUT
+        if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if git diff --quiet HEAD^ HEAD -- apps/expo; then
+            echo "Expo project not modified"
+            echo "skip_job=true" >> $GITHUB_OUTPUT
+          else
+            echo "Expo project modified"
+            echo "skip_job=false" >> $GITHUB_OUTPUT
+          fi
         else
-          echo "Expo project modified"
-          echo "skip_job=false" >> $GITHUB_OUTPUT
+          if git diff --quiet origin/main HEAD -- apps/expo; then
+            echo "Expo project not modified"
+            echo "skip_job=true" >> $GITHUB_OUTPUT
+          else
+            echo "Expo project modified"
+            echo "skip_job=false" >> $GITHUB_OUTPUT
+          fi
         fi
-        
+
     - name: Setup pnpm
       uses: pnpm/action-setup@v2.4.0
       if: ${{ steps.check-expo.outputs.skip_job == 'false' }}
@@ -173,12 +183,22 @@ jobs:
     - name: Check for changes to Expo app
       id: check-expo
       run: |
-        if git diff --quiet origin/main HEAD -- apps/expo; then
-          echo "Expo project not modified"
-          echo "skip_job=true" >> $GITHUB_OUTPUT
+        if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if git diff --quiet HEAD^ HEAD -- apps/expo; then
+            echo "Expo project not modified"
+            echo "skip_job=true" >> $GITHUB_OUTPUT
+          else
+            echo "Expo project modified"
+            echo "skip_job=false" >> $GITHUB_OUTPUT
+          fi
         else
-          echo "Expo project modified"
-          echo "skip_job=false" >> $GITHUB_OUTPUT
+          if git diff --quiet origin/main HEAD -- apps/expo; then
+            echo "Expo project not modified"
+            echo "skip_job=true" >> $GITHUB_OUTPUT
+          else
+            echo "Expo project modified"
+            echo "skip_job=false" >> $GITHUB_OUTPUT
+          fi
         fi
 
     - name: Setup pnpm


### PR DESCRIPTION
### Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. --->
Fixes ignore command so that iOS and Android builds are run on main branch.

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->
Previous command would compare to the main branch (good for PRs), but this means that any commit to main branch will cause the workflow to be ignored.
