### PR TITLE
[CFD-55] Add postType to post model

### DIFF
--- a/packages/api/src/router/post.ts
+++ b/packages/api/src/router/post.ts
@@ -1,6 +1,70 @@
+import type { SignedInAuthObject } from "@clerk/clerk-sdk-node";
+import type { PrismaClient } from "@prisma/client";
 import { z } from "zod";
 
-import { createTRPCRouter, protectedProcedure } from "../trpc";
+import { adminProcedure, createTRPCRouter, protectedProcedure } from "../trpc";
+
+const basePostInput = {
+  title: z.string().trim().min(1).max(300),
+  contents: z.string().min(1),
+};
+
+const createPostInput = z.object({
+  ...basePostInput,
+});
+
+const updatePostInput = z
+  .object({
+    id: z.number().nonnegative(),
+    ...basePostInput,
+  })
+  .partial();
+
+const deletePostInput = z.object({
+  id: z.number().nonnegative(),
+});
+
+const createPost = async (
+  ctx: { db: PrismaClient; auth: SignedInAuthObject },
+  input: z.infer<typeof createPostInput>,
+  postType: "Announcement" | "Discussion",
+) => {
+  await ctx.db.post.create({
+    data: {
+      ...input,
+      postType,
+    },
+  });
+};
+
+const updatePost = async (
+  ctx: { db: PrismaClient; auth: SignedInAuthObject },
+  input: z.infer<typeof updatePostInput>,
+  postType: "Announcement" | "Discussion",
+) => {
+  await ctx.db.post.update({
+    where: {
+      id: input.id,
+      postType,
+    },
+    data: {
+      ...input,
+    },
+  });
+};
+
+const deletePost = async (
+  ctx: { db: PrismaClient; auth: SignedInAuthObject },
+  input: z.infer<typeof updatePostInput>,
+  postType: "Announcement" | "Discussion",
+) => {
+  await ctx.db.post.delete({
+    where: {
+      id: input.id,
+      postType,
+    },
+  });
+};
 
 export const postRouter = createTRPCRouter({
   getPosts: protectedProcedure.query(async ({ ctx }) => {
@@ -9,50 +73,33 @@ export const postRouter = createTRPCRouter({
     });
   }),
   createPost: protectedProcedure
-    .input(
-      z.object({
-        title: z.string().trim().min(1).max(300),
-        contents: z.string().min(1),
-        postType: z.enum(["Announcement", "Discussion"]),
-      }),
-    )
+    .input(createPostInput)
     .mutation(async ({ ctx, input }) => {
-      await ctx.db.post.create({
-        data: {
-          title: input.title,
-          contents: input.contents,
-          postType: input.postType,
-        },
-      });
+      await createPost(ctx, input, "Discussion");
+    }),
+  createAnnouncement: adminProcedure
+    .input(createPostInput)
+    .mutation(async ({ ctx, input }) => {
+      await createPost(ctx, input, "Announcement");
     }),
   updatePostByID: protectedProcedure
-    .input(
-      z.object({
-        id: z.number().nonnegative(),
-        title: z.string().optional(),
-        contents: z.string().optional(),
-        postType: z.enum(["Announcement", "Discussion"]),
-      }),
-    )
+    .input(updatePostInput)
     .mutation(async ({ ctx, input }) => {
-      await ctx.db.post.update({
-        where: {
-          id: input.id,
-        },
-        data: {
-          title: input.title,
-          contents: input.contents,
-          postType: input.postType,
-        },
-      });
+      await updatePost(ctx, input, "Discussion");
+    }),
+  updateAnnouncementByID: adminProcedure
+    .input(updatePostInput)
+    .mutation(async ({ ctx, input }) => {
+      await updatePost(ctx, input, "Announcement");
     }),
   deletePostByID: protectedProcedure
-    .input(z.object({ id: z.number().nonnegative() }))
+    .input(deletePostInput)
     .mutation(async ({ ctx, input }) => {
-      await ctx.db.post.delete({
-        where: {
-          id: input.id,
-        },
-      });
+      await deletePost(ctx, input, "Discussion");
+    }),
+  deleteAnnouncementByID: adminProcedure
+    .input(deletePostInput)
+    .mutation(async ({ ctx, input }) => {
+      await deletePost(ctx, input, "Announcement");
     }),
 });

--- a/packages/api/src/router/post.ts
+++ b/packages/api/src/router/post.ts
@@ -13,6 +13,7 @@ export const postRouter = createTRPCRouter({
       z.object({
         title: z.string().trim().min(1).max(300),
         contents: z.string().min(1),
+        postType: z.enum(["Announcement", "Discussion"]),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -20,6 +21,7 @@ export const postRouter = createTRPCRouter({
         data: {
           title: input.title,
           contents: input.contents,
+          postType: input.postType,
         },
       });
     }),
@@ -29,6 +31,7 @@ export const postRouter = createTRPCRouter({
         id: z.number().nonnegative(),
         title: z.string().optional(),
         contents: z.string().optional(),
+        postType: z.enum(["Announcement", "Discussion"]),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -39,6 +42,7 @@ export const postRouter = createTRPCRouter({
         data: {
           title: input.title,
           contents: input.contents,
+          postType: input.postType,
         },
       });
     }),

--- a/packages/api/src/router/post.ts
+++ b/packages/api/src/router/post.ts
@@ -1,4 +1,3 @@
-import type { SignedInAuthObject } from "@clerk/clerk-sdk-node";
 import type { PrismaClient } from "@prisma/client";
 import { z } from "zod";
 
@@ -25,11 +24,11 @@ const deletePostInput = z.object({
 });
 
 const createPost = async (
-  ctx: { db: PrismaClient; auth: SignedInAuthObject },
+  db: PrismaClient,
   input: z.infer<typeof createPostInput>,
   postType: "Announcement" | "Discussion",
 ) => {
-  await ctx.db.post.create({
+  await db.post.create({
     data: {
       ...input,
       postType,
@@ -38,11 +37,11 @@ const createPost = async (
 };
 
 const updatePost = async (
-  ctx: { db: PrismaClient; auth: SignedInAuthObject },
+  db: PrismaClient,
   input: z.infer<typeof updatePostInput>,
   postType: "Announcement" | "Discussion",
 ) => {
-  await ctx.db.post.update({
+  await db.post.update({
     where: {
       id: input.id,
       postType,
@@ -54,11 +53,11 @@ const updatePost = async (
 };
 
 const deletePost = async (
-  ctx: { db: PrismaClient; auth: SignedInAuthObject },
+  db: PrismaClient,
   input: z.infer<typeof updatePostInput>,
   postType: "Announcement" | "Discussion",
 ) => {
-  await ctx.db.post.delete({
+  await db.post.delete({
     where: {
       id: input.id,
       postType,
@@ -75,31 +74,31 @@ export const postRouter = createTRPCRouter({
   createPost: protectedProcedure
     .input(createPostInput)
     .mutation(async ({ ctx, input }) => {
-      await createPost(ctx, input, "Discussion");
+      await createPost(ctx.db, input, "Discussion");
     }),
   createAnnouncement: adminProcedure
     .input(createPostInput)
     .mutation(async ({ ctx, input }) => {
-      await createPost(ctx, input, "Announcement");
+      await createPost(ctx.db, input, "Announcement");
     }),
   updatePostByID: protectedProcedure
     .input(updatePostInput)
     .mutation(async ({ ctx, input }) => {
-      await updatePost(ctx, input, "Discussion");
+      await updatePost(ctx.db, input, "Discussion");
     }),
   updateAnnouncementByID: adminProcedure
     .input(updatePostInput)
     .mutation(async ({ ctx, input }) => {
-      await updatePost(ctx, input, "Announcement");
+      await updatePost(ctx.db, input, "Announcement");
     }),
   deletePostByID: protectedProcedure
     .input(deletePostInput)
     .mutation(async ({ ctx, input }) => {
-      await deletePost(ctx, input, "Discussion");
+      await deletePost(ctx.db, input, "Discussion");
     }),
   deleteAnnouncementByID: adminProcedure
     .input(deletePostInput)
     .mutation(async ({ ctx, input }) => {
-      await deletePost(ctx, input, "Announcement");
+      await deletePost(ctx.db, input, "Announcement");
     }),
 });

--- a/packages/api/src/router/post.ts
+++ b/packages/api/src/router/post.ts
@@ -1,69 +1,6 @@
-import type { PrismaClient } from "@prisma/client";
 import { z } from "zod";
 
-import { adminProcedure, createTRPCRouter, protectedProcedure } from "../trpc";
-
-const basePostInput = {
-  title: z.string().trim().min(1).max(300),
-  contents: z.string().min(1),
-};
-
-const createPostInput = z.object({
-  ...basePostInput,
-});
-
-const updatePostInput = z
-  .object({
-    id: z.number().nonnegative(),
-    ...basePostInput,
-  })
-  .partial();
-
-const deletePostInput = z.object({
-  id: z.number().nonnegative(),
-});
-
-const createPost = async (
-  db: PrismaClient,
-  input: z.infer<typeof createPostInput>,
-  postType: "Announcement" | "Discussion",
-) => {
-  await db.post.create({
-    data: {
-      ...input,
-      postType,
-    },
-  });
-};
-
-const updatePost = async (
-  db: PrismaClient,
-  input: z.infer<typeof updatePostInput>,
-  postType: "Announcement" | "Discussion",
-) => {
-  await db.post.update({
-    where: {
-      id: input.id,
-      postType,
-    },
-    data: {
-      ...input,
-    },
-  });
-};
-
-const deletePost = async (
-  db: PrismaClient,
-  input: z.infer<typeof updatePostInput>,
-  postType: "Announcement" | "Discussion",
-) => {
-  await db.post.delete({
-    where: {
-      id: input.id,
-      postType,
-    },
-  });
-};
+import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const postRouter = createTRPCRouter({
   getPosts: protectedProcedure.query(async ({ ctx }) => {
@@ -72,33 +9,48 @@ export const postRouter = createTRPCRouter({
     });
   }),
   createPost: protectedProcedure
-    .input(createPostInput)
+    .input(
+      z.object({
+        title: z.string().trim().min(1).max(300),
+        contents: z.string().min(1),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
-      await createPost(ctx.db, input, "Discussion");
-    }),
-  createAnnouncement: adminProcedure
-    .input(createPostInput)
-    .mutation(async ({ ctx, input }) => {
-      await createPost(ctx.db, input, "Announcement");
+      await ctx.db.post.create({
+        data: {
+          title: input.title,
+          contents: input.contents,
+          postType: "Discussion",
+        },
+      });
     }),
   updatePostByID: protectedProcedure
-    .input(updatePostInput)
+    .input(
+      z.object({
+        id: z.number().nonnegative(),
+        title: z.string().optional(),
+        contents: z.string().optional(),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
-      await updatePost(ctx.db, input, "Discussion");
-    }),
-  updateAnnouncementByID: adminProcedure
-    .input(updatePostInput)
-    .mutation(async ({ ctx, input }) => {
-      await updatePost(ctx.db, input, "Announcement");
+      await ctx.db.post.update({
+        where: {
+          id: input.id,
+        },
+        data: {
+          title: input.title,
+          contents: input.contents,
+          postType: "Discussion",
+        },
+      });
     }),
   deletePostByID: protectedProcedure
-    .input(deletePostInput)
+    .input(z.object({ id: z.number().nonnegative() }))
     .mutation(async ({ ctx, input }) => {
-      await deletePost(ctx.db, input, "Discussion");
-    }),
-  deleteAnnouncementByID: adminProcedure
-    .input(deletePostInput)
-    .mutation(async ({ ctx, input }) => {
-      await deletePost(ctx.db, input, "Announcement");
+      await ctx.db.post.delete({
+        where: {
+          id: input.id,
+        },
+      });
     }),
 });

--- a/packages/api/src/router/post.ts
+++ b/packages/api/src/router/post.ts
@@ -40,7 +40,6 @@ export const postRouter = createTRPCRouter({
         data: {
           title: input.title,
           contents: input.contents,
-          postType: "Discussion",
         },
       });
     }),

--- a/packages/db/prisma/migrations/20231105001203_add_post_type/migration.sql
+++ b/packages/db/prisma/migrations/20231105001203_add_post_type/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `postType` to the `Post` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "PostType" AS ENUM ('Announcement', 'Discussion');
+
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "postType" "PostType" NOT NULL;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Post {
   contents  String
   createdAt DateTime  @default(now())
   comments  Comment[]
+  postType  PostType
 }
 
 model Comment {
@@ -53,4 +54,9 @@ model Absence {
   absenceDate DateTime @db.Date
 
   @@unique([absenceDate, userId])
+}
+
+enum PostType {
+  Announcement
+  Discussion
 }


### PR DESCRIPTION
### Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. --->

Adds a PostType enum (currently with two options: announcement and discussion) and adds a postType field to posts

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->

<!--- Please delete options that are not relevant for linking your ticket. You likely only need one of these for your PR --->

Completes CFD-55

### Type of change
<!--- Please delete options that are not relevant. --->

- [x] New feature (non-breaking change which adds functionality)

### Testing
<!--- Please describe the tests that you ran to verify your changes. This may be a screenshot of the change that you made. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration --->

New field and endpoint changes works as expected in Prisma Studio and tRPC panel

<img width="824" alt="image" src="https://github.com/uoftblueprint/centre-for-dreams/assets/40612523/cb00477d-0681-4017-9dfc-96ea7b5e1c3c">

