### PR TITLE
Make Expo Go the default for development

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -5,7 +5,7 @@
   "main": "index.tsx",
   "scripts": {
     "clean": "git clean -xdf .expo .turbo node_modules",
-    "dev": "expo start",
+    "dev": "expo start --go",
     "dev:android": "expo start --android",
     "dev:ios": "expo start --ios",
     "lint": "eslint .",


### PR DESCRIPTION
### Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. --->
Makes Expo Go the default for when `pnpm dev` is used.

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->
Not sure why, but it no longer defaults to expo go

### Testing
Tested locally and confirmed it works
