### PR TITLE
Remove Client Logger Dependency

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@cfd/api": "^0.1.0",
-    "@cfd/logger": "^0.1.0",
     "@clerk/nextjs": "^4.26.1",
     "@t3-oss/env-nextjs": "^0.7.1",
     "@tanstack/react-query": "^4.36.1",

--- a/apps/nextjs/src/utils/api.ts
+++ b/apps/nextjs/src/utils/api.ts
@@ -10,7 +10,6 @@ import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
 import superjson from "superjson";
 
 import type { AppRouter } from "@cfd/api";
-import { logger } from "@cfd/logger";
 
 const getBaseUrl = () => {
   if (typeof window !== "undefined") return ""; // browser should use relative url
@@ -36,7 +35,6 @@ export const api = createTRPCNext<AppRouter>({
        */
       links: [
         loggerLink({
-          logger: (o) => logger.info(o),
           enabled: (opts) =>
             process.env.NODE_ENV === "development" ||
             (opts.direction === "down" && opts.result instanceof Error),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,9 +147,6 @@ importers:
       '@cfd/api':
         specifier: ^0.1.0
         version: link:../../packages/api
-      '@cfd/logger':
-        specifier: ^0.1.0
-        version: link:../../packages/logger
       '@clerk/nextjs':
         specifier: ^4.26.1
         version: 4.26.1(next@13.4.12)(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
### Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. --->
Removes `@cfd/logger` as a dependency of the Next.js app.

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->
The logger was included for logging requests, but this should only be done on the server side, not on the client side. This also slightly reduces the bundle size of the web app.

### Type of change
<!--- Please delete options that are not relevant. --->

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing
<!--- Please describe the tests that you ran to verify your changes. This may be a screenshot of the change that you made. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration --->

- [x] Ran Next Bundle Analyzer and confirmed that Pino is no longer included in the client bundle
