### PR TITLE
Sarinali/cfd 49 schedule frontend page (View activites and create activites)

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -35,6 +35,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.72.6",
     "react-native-gesture-handler": "~2.12.0",
+    "react-native-modal-datetime-picker": "^17.1.0",
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.22.1",
     "superjson": "2.2.0"

--- a/apps/expo/src/app/activites.tsx
+++ b/apps/expo/src/app/activites.tsx
@@ -1,14 +1,16 @@
 import React from "react";
-import { View } from "react-native";
+import { ScrollView } from "react-native";
+
 import CreateActivityComponent from "./components/createactivity";
 import ViewActivitiesComponent from "./components/viewactivites";
 
 const Activities = () => {
-  
-  return <View className="h-full w-full p-4">
-    <ViewActivitiesComponent></ViewActivitiesComponent>
-    <CreateActivityComponent></CreateActivityComponent>
-  </View>;
+  return (
+    <ScrollView className="h-full w-full p-4">
+      <ViewActivitiesComponent></ViewActivitiesComponent>
+      <CreateActivityComponent></CreateActivityComponent>
+    </ScrollView>
+  );
 };
 
 export default Activities;

--- a/apps/expo/src/app/activites.tsx
+++ b/apps/expo/src/app/activites.tsx
@@ -1,127 +1,14 @@
-import React, { useState } from "react";
-import { Alert, Button, Text, TextInput, View } from "react-native";
-import { api } from "~/utils/api";
-import DateTimePickerModal from "react-native-modal-datetime-picker";
+import React from "react";
+import { View } from "react-native";
+import CreateActivityComponent from "./components/createactivity";
+import ViewActivitiesComponent from "./components/viewactivites";
 
 const Activities = () => {
-    // activites from a given week
-
-    const currentDateTime: Date = new Date();
-    const [selectedDate, setSelectedDate] = useState(currentDateTime);
-    const [datePickerVisible, setDatePickerVisible] = useState(false);
-
-    const showDatePicker = () => {
-      setDatePickerVisible(true);
-    };
-    
-    const hideDatePicker = () => {
-      setDatePickerVisible(false);
-    };
-
-    // create an activity
-    const [activityData, setActivityData] = useState({
-        name: "",
-        duration: "",
-        leader: "",
-        location: "",
-        selectedDate: currentDateTime,
-    });
-
-    const handleInputChange = (field: string, value: string | number) => {
-        setActivityData({
-          ...activityData,
-          [field]: value,
-        });
-    };
-
-    const handleDateConfirm = (date: Date) => {
   
-      setActivityData({
-        ...activityData,
-        selectedDate: date,
-      });
-      setSelectedDate(date);
-      hideDatePicker();
-  
-    };
-
-    const handleSubmit = () => {
-        if (
-            activityData.name === "" ||
-            activityData.duration === "" ||
-            activityData.leader === "" ||
-            activityData.location === ""
-          ) {
-            // Display an alert if any field is empty
-            Alert.alert("Empty Field!", "Please fill in all fields");
-            return;
-        }
-
-        const duration = parseInt(activityData.duration, 10);
-
-        console.log("Form data:", {
-        ...activityData,
-        duration: duration, 
-        });
-
-        const currentDateTime: Date = new Date();
-        console.log("Form data:", activityData);
-        // createActivity.mutate({name: activityData.name, day: currentDateTime, startTime: currentDateTime, })
-        setActivityData({
-          name: "",
-          duration: "",
-          leader: "",
-          location: "",
-          selectedDate: currentDateTime
-        });
-    };
-
-    return (
-        <View className="h-full w-full p-4">
-            <Text>Name:</Text>
-      <TextInput
-        placeholder="Enter name"
-        value={activityData.name}
-        onChangeText={(text) => handleInputChange("name", text)}
-      />
-
-      <Text>Duration:</Text>
-      <TextInput
-        placeholder="Enter duration"
-        value={activityData.duration}
-        onChangeText={(text) => handleInputChange("duration", text)}
-        keyboardType="numeric" // This sets the keyboard to numeric for this input
-      />
-
-      <Text>Leader:</Text>
-      <TextInput
-        placeholder="Enter leader"
-        value={activityData.leader}
-        onChangeText={(text) => handleInputChange("leader", text)}
-      />
-
-      <Text>Location:</Text>
-      <TextInput
-        placeholder="Enter location"
-        value={activityData.location}
-        onChangeText={(text) => handleInputChange("location", text)}
-      />
-      
-      <Text style={{ fontSize: 24, fontWeight: 'bold', marginBottom: 20 }}>
-        {selectedDate ? selectedDate.toISOString() : 'No date selected'}
-      </Text>
-      <Button title="Select a date" onPress={showDatePicker} />
-
-      <Button title="Submit" onPress={handleSubmit} />
-      <DateTimePickerModal
-        // date={selectedDate}
-        isVisible={datePickerVisible}
-        mode="date"
-        onConfirm={handleDateConfirm}
-        onCancel={hideDatePicker}
-      />
-        </View>
-    );
+  return <View className="h-full w-full p-4">
+    <ViewActivitiesComponent></ViewActivitiesComponent>
+    <CreateActivityComponent></CreateActivityComponent>
+  </View>;
 };
 
 export default Activities;

--- a/apps/expo/src/app/activites.tsx
+++ b/apps/expo/src/app/activites.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from "react";
+import { Alert, Button, Text, TextInput, View } from "react-native";
+import { api } from "~/utils/api";
+import DateTimePickerModal from "react-native-modal-datetime-picker";
+
+const Activities = () => {
+    // activites from a given week
+
+    const currentDateTime: Date = new Date();
+    const [selectedDate, setSelectedDate] = useState(currentDateTime);
+    const [datePickerVisible, setDatePickerVisible] = useState(false);
+
+    const showDatePicker = () => {
+      setDatePickerVisible(true);
+    };
+    
+    const hideDatePicker = () => {
+      setDatePickerVisible(false);
+    };
+
+    // create an activity
+    const [activityData, setActivityData] = useState({
+        name: "",
+        duration: "",
+        leader: "",
+        location: "",
+        selectedDate: currentDateTime,
+    });
+
+    const handleInputChange = (field: string, value: string | number) => {
+        setActivityData({
+          ...activityData,
+          [field]: value,
+        });
+    };
+
+    const handleDateConfirm = (date: Date) => {
+  
+      setActivityData({
+        ...activityData,
+        selectedDate: date,
+      });
+      setSelectedDate(date);
+      hideDatePicker();
+  
+    };
+
+    const handleSubmit = () => {
+        if (
+            activityData.name === "" ||
+            activityData.duration === "" ||
+            activityData.leader === "" ||
+            activityData.location === ""
+          ) {
+            // Display an alert if any field is empty
+            Alert.alert("Empty Field!", "Please fill in all fields");
+            return;
+        }
+
+        const duration = parseInt(activityData.duration, 10);
+
+        console.log("Form data:", {
+        ...activityData,
+        duration: duration, 
+        });
+
+        const currentDateTime: Date = new Date();
+        console.log("Form data:", activityData);
+        // createActivity.mutate({name: activityData.name, day: currentDateTime, startTime: currentDateTime, })
+        setActivityData({
+          name: "",
+          duration: "",
+          leader: "",
+          location: "",
+          selectedDate: currentDateTime
+        });
+    };
+
+    return (
+        <View className="h-full w-full p-4">
+            <Text>Name:</Text>
+      <TextInput
+        placeholder="Enter name"
+        value={activityData.name}
+        onChangeText={(text) => handleInputChange("name", text)}
+      />
+
+      <Text>Duration:</Text>
+      <TextInput
+        placeholder="Enter duration"
+        value={activityData.duration}
+        onChangeText={(text) => handleInputChange("duration", text)}
+        keyboardType="numeric" // This sets the keyboard to numeric for this input
+      />
+
+      <Text>Leader:</Text>
+      <TextInput
+        placeholder="Enter leader"
+        value={activityData.leader}
+        onChangeText={(text) => handleInputChange("leader", text)}
+      />
+
+      <Text>Location:</Text>
+      <TextInput
+        placeholder="Enter location"
+        value={activityData.location}
+        onChangeText={(text) => handleInputChange("location", text)}
+      />
+      
+      <Text style={{ fontSize: 24, fontWeight: 'bold', marginBottom: 20 }}>
+        {selectedDate ? selectedDate.toISOString() : 'No date selected'}
+      </Text>
+      <Button title="Select a date" onPress={showDatePicker} />
+
+      <Button title="Submit" onPress={handleSubmit} />
+      <DateTimePickerModal
+        // date={selectedDate}
+        isVisible={datePickerVisible}
+        mode="date"
+        onConfirm={handleDateConfirm}
+        onCancel={hideDatePicker}
+      />
+        </View>
+    );
+};
+
+export default Activities;

--- a/apps/expo/src/app/components/createactivity.tsx
+++ b/apps/expo/src/app/components/createactivity.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from "react";
+import { Alert, Button, Text, TextInput, View } from "react-native";
+import DateTimePickerModal from "react-native-modal-datetime-picker";
+import { api } from "~/utils/api";
+
+const CreateActivityComponent = () => {
+    const createActivity = api.activity.createActivity.useMutation();
+  const currentDateTime: Date = new Date();
+  const [selectedDate, setSelectedDate] = useState(currentDateTime);
+  const [datePickerVisible, setDatePickerVisible] = useState(false);
+
+  const showDatePicker = () => {
+    setDatePickerVisible(true);
+  };
+
+  const hideDatePicker = () => {
+    setDatePickerVisible(false);
+  };
+
+  const [activityData, setActivityData] = useState({
+    name: "",
+    duration: "",
+    leader: "",
+    location: "",
+    selectedDate: currentDateTime,
+  });
+
+  const handleInputChange = (field: string, value: string | number) => {
+    setActivityData({
+      ...activityData,
+      [field]: value,
+    });
+  };
+
+  const handleDateConfirm = (date: Date) => {
+    setActivityData({
+      ...activityData,
+      selectedDate: date,
+    });
+    setSelectedDate(date);
+    hideDatePicker();
+  };
+
+  const handleSubmit = () => {
+    if (
+      activityData.name === "" ||
+      activityData.duration === "" ||
+      activityData.leader === "" ||
+      activityData.location === ""
+    ) {
+      // Display an alert if any field is empty
+      Alert.alert("Empty Field!", "Please fill in all fields");
+      return;
+    }
+
+    const duration = parseInt(activityData.duration, 10);
+
+    console.log("Form data:", {
+      ...activityData,
+      duration: duration,
+    });
+
+    createActivity.mutate({name: activityData.name, day: currentDateTime, startTime: selectedDate, durationMinutes: duration, leader: activityData.leader, location: activityData.location});
+
+    console.log("Form data:", activityData);
+    setActivityData({
+      name: "",
+      duration: "",
+      leader: "",
+      location: "",
+      selectedDate: currentDateTime,
+    });
+  };
+
+  return (
+    <View>
+      <Text>Name:</Text>
+      <TextInput
+        placeholder="Enter name"
+        value={activityData.name}
+        onChangeText={(text) => handleInputChange("name", text)}
+      />
+
+      <Text>Duration:</Text>
+      <TextInput
+        placeholder="Enter duration"
+        value={activityData.duration}
+        onChangeText={(text) => handleInputChange("duration", text)}
+        keyboardType="numeric" // This sets the keyboard to numeric for this input
+      />
+
+      <Text>Leader:</Text>
+      <TextInput
+        placeholder="Enter leader"
+        value={activityData.leader}
+        onChangeText={(text) => handleInputChange("leader", text)}
+      />
+
+      <Text>Location:</Text>
+      <TextInput
+        placeholder="Enter location"
+        value={activityData.location}
+        onChangeText={(text) => handleInputChange("location", text)}
+      />
+      <Text>Date:</Text>
+      <Text>
+        {selectedDate ? selectedDate.toUTCString() : "No date selected"}
+      </Text>
+      <Button title="Select a date" onPress={showDatePicker} />
+
+      <Button title="Submit" onPress={handleSubmit} />
+      <DateTimePickerModal
+        date={selectedDate}
+        isVisible={datePickerVisible}
+        mode="date"
+        onConfirm={handleDateConfirm}
+        onCancel={hideDatePicker}
+      />
+    </View>
+  );
+};
+
+export default CreateActivityComponent;

--- a/apps/expo/src/app/components/createactivity.tsx
+++ b/apps/expo/src/app/components/createactivity.tsx
@@ -1,20 +1,31 @@
 import React, { useState } from "react";
 import { Alert, Button, Text, TextInput, View } from "react-native";
 import DateTimePickerModal from "react-native-modal-datetime-picker";
+
 import { api } from "~/utils/api";
 
 const CreateActivityComponent = () => {
-    const createActivity = api.activity.createActivity.useMutation();
+  const createActivity = api.activity.createActivity.useMutation();
   const currentDateTime: Date = new Date();
   const [selectedDate, setSelectedDate] = useState(currentDateTime);
   const [datePickerVisible, setDatePickerVisible] = useState(false);
+  const [selectedStartDate, setselectedStartDate] = useState(currentDateTime);
+  const [startDatePickerVisible, setStartDatePickerVisible] = useState(false);
 
   const showDatePicker = () => {
     setDatePickerVisible(true);
   };
 
+  const showStartDatePicker = () => {
+    setStartDatePickerVisible(true);
+  };
+
   const hideDatePicker = () => {
     setDatePickerVisible(false);
+  };
+
+  const hideStartDatePicker = () => {
+    setStartDatePickerVisible(false);
   };
 
   const [activityData, setActivityData] = useState({
@@ -23,6 +34,7 @@ const CreateActivityComponent = () => {
     leader: "",
     location: "",
     selectedDate: currentDateTime,
+    startDate: currentDateTime,
   });
 
   const handleInputChange = (field: string, value: string | number) => {
@@ -41,6 +53,15 @@ const CreateActivityComponent = () => {
     hideDatePicker();
   };
 
+  const handleStartDateConfirm = (date: Date) => {
+    setActivityData({
+      ...activityData,
+      startDate: date,
+    });
+    setselectedStartDate(date);
+    hideStartDatePicker();
+  };
+
   const handleSubmit = () => {
     if (
       activityData.name === "" ||
@@ -48,7 +69,6 @@ const CreateActivityComponent = () => {
       activityData.leader === "" ||
       activityData.location === ""
     ) {
-      // Display an alert if any field is empty
       Alert.alert("Empty Field!", "Please fill in all fields");
       return;
     }
@@ -60,15 +80,22 @@ const CreateActivityComponent = () => {
       duration: duration,
     });
 
-    createActivity.mutate({name: activityData.name, day: currentDateTime, startTime: selectedDate, durationMinutes: duration, leader: activityData.leader, location: activityData.location});
+    createActivity.mutate({
+      name: activityData.name,
+      day: selectedDate,
+      durationMinutes: duration,
+      leader: activityData.leader,
+      location: activityData.location,
+      startTime: activityData.startDate,
+    });
 
-    console.log("Form data:", activityData);
     setActivityData({
       name: "",
       duration: "",
       leader: "",
       location: "",
       selectedDate: currentDateTime,
+      startDate: currentDateTime,
     });
   };
 
@@ -106,9 +133,13 @@ const CreateActivityComponent = () => {
       <Text>
         {selectedDate ? selectedDate.toUTCString() : "No date selected"}
       </Text>
+      <Text>Start Time:</Text>
+      <Text>
+        {selectedStartDate
+          ? selectedStartDate.toUTCString()
+          : "No start date selected"}
+      </Text>
       <Button title="Select a date" onPress={showDatePicker} />
-
-      <Button title="Submit" onPress={handleSubmit} />
       <DateTimePickerModal
         date={selectedDate}
         isVisible={datePickerVisible}
@@ -116,6 +147,15 @@ const CreateActivityComponent = () => {
         onConfirm={handleDateConfirm}
         onCancel={hideDatePicker}
       />
+      <Button title="Select a start date" onPress={showStartDatePicker} />
+      <DateTimePickerModal
+        date={selectedStartDate}
+        isVisible={startDatePickerVisible}
+        mode="date"
+        onConfirm={handleStartDateConfirm}
+        onCancel={hideStartDatePicker}
+      />
+      <Button title="Submit" onPress={handleSubmit} />
     </View>
   );
 };

--- a/apps/expo/src/app/components/viewactivites.tsx
+++ b/apps/expo/src/app/components/viewactivites.tsx
@@ -1,44 +1,54 @@
-import { Button, View, Text } from "react-native";
-// import { api } from "~/utils/api";
-import DateTimePickerModal from "react-native-modal-datetime-picker";
 import { useState } from "react";
+import { Button, FlatList, Text, View } from "react-native";
+import DateTimePickerModal from "react-native-modal-datetime-picker";
+
+import { api } from "~/utils/api";
 
 const ViewActivitiesComponent = () => {
-    const currentDateTime: Date = new Date();
-    const [selectedDate, setSelectedDate] = useState(currentDateTime);
-    const [datePickerVisible, setDatePickerVisible] = useState(false);
-    // const viewAcitivtes = api.activity.getSchedule.useQuery({day: selectedDate});
+  const currentDateTime: Date = new Date();
+  const [selectedDate, setSelectedDate] = useState(currentDateTime);
+  const [datePickerVisible, setDatePickerVisible] = useState(false);
+  const viewAcitivtes = api.activity.getSchedule.useQuery({
+    day: selectedDate,
+  });
 
-    const showDatePicker = () => {
-        setDatePickerVisible(true);
-    };
+  const showDatePicker = () => {
+    setDatePickerVisible(true);
+  };
 
-    const hideDatePicker = () => {
-        setDatePickerVisible(false);
-    };
-    
-    const handleDateConfirm = (date: Date) => {
-        setSelectedDate(date);
-        hideDatePicker();
-    };
+  const hideDatePicker = () => {
+    setDatePickerVisible(false);
+  };
 
+  const handleDateConfirm = (date: Date) => {
+    setSelectedDate(date);
+    hideDatePicker();
+    console.log(viewAcitivtes.data);
+  };
 
-
-    return (
-        <View>
-            <Text>
-                {selectedDate ? selectedDate.toUTCString() : "No date selected"}
-            </Text>
-            <Button title="Select a date" onPress={showDatePicker} />
-            <DateTimePickerModal
-                date={selectedDate}
-                isVisible={datePickerVisible}
-                mode="date"
-                onConfirm={handleDateConfirm}
-                onCancel={hideDatePicker}
-            />
-        </View>
-    );
-}
+  return (
+    <View>
+      <Text>
+        {selectedDate ? selectedDate.toUTCString() : "No date selected"}
+      </Text>
+      <Button title="Select a date" onPress={showDatePicker} />
+      <DateTimePickerModal
+        date={selectedDate}
+        isVisible={datePickerVisible}
+        mode="date"
+        onConfirm={handleDateConfirm}
+        onCancel={hideDatePicker}
+      />
+      <FlatList
+        data={viewAcitivtes.data}
+        renderItem={({ item }) => (
+          <View>
+            <Text>{JSON.stringify(item, null, 2)}</Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+};
 
 export default ViewActivitiesComponent;

--- a/apps/expo/src/app/components/viewactivites.tsx
+++ b/apps/expo/src/app/components/viewactivites.tsx
@@ -1,0 +1,44 @@
+import { Button, View, Text } from "react-native";
+// import { api } from "~/utils/api";
+import DateTimePickerModal from "react-native-modal-datetime-picker";
+import { useState } from "react";
+
+const ViewActivitiesComponent = () => {
+    const currentDateTime: Date = new Date();
+    const [selectedDate, setSelectedDate] = useState(currentDateTime);
+    const [datePickerVisible, setDatePickerVisible] = useState(false);
+    // const viewAcitivtes = api.activity.getSchedule.useQuery({day: selectedDate});
+
+    const showDatePicker = () => {
+        setDatePickerVisible(true);
+    };
+
+    const hideDatePicker = () => {
+        setDatePickerVisible(false);
+    };
+    
+    const handleDateConfirm = (date: Date) => {
+        setSelectedDate(date);
+        hideDatePicker();
+    };
+
+
+
+    return (
+        <View>
+            <Text>
+                {selectedDate ? selectedDate.toUTCString() : "No date selected"}
+            </Text>
+            <Button title="Select a date" onPress={showDatePicker} />
+            <DateTimePickerModal
+                date={selectedDate}
+                isVisible={datePickerVisible}
+                mode="date"
+                onConfirm={handleDateConfirm}
+                onCancel={hideDatePicker}
+            />
+        </View>
+    );
+}
+
+export default ViewActivitiesComponent;

--- a/apps/expo/src/app/index.tsx
+++ b/apps/expo/src/app/index.tsx
@@ -5,6 +5,7 @@ import * as Notifications from "expo-notifications";
 import { Stack } from "expo-router";
 
 import registerForPushNotificationsAsync from "~/notifications/registerNotifications";
+import Activities from "./activites";
 
 Notifications.setNotificationHandler({
   handleNotification: () =>
@@ -29,9 +30,10 @@ const Index = () => {
     <SafeAreaView className="">
       {/* Changes page title visible on the header */}
       <Stack.Screen options={{ title: "Home Page" }} />
-      <View className="h-full w-full p-4">
+      {/* <View className="h-full w-full p-4">
         <Text> Index </Text>
-      </View>
+      </View> */}
+      <Activities></Activities>
     </SafeAreaView>
   );
 };

--- a/apps/expo/src/app/index.tsx
+++ b/apps/expo/src/app/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import * as Notifications from "expo-notifications";
 import { Stack } from "expo-router";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       react-native-gesture-handler:
         specifier: ~2.12.0
         version: 2.12.1(react-native@0.72.6)(react@18.2.0)
+      react-native-modal-datetime-picker:
+        specifier: ^17.1.0
+        version: 17.1.0(@react-native-community/datetimepicker@7.6.1)(react-native@0.72.6)
       react-native-safe-area-context:
         specifier: 4.6.3
         version: 4.6.3(react-native@0.72.6)(react@18.2.0)
@@ -2947,6 +2950,12 @@ packages:
       - encoding
       - supports-color
       - utf-8-validate
+    dev: false
+
+  /@react-native-community/datetimepicker@7.6.1:
+    resolution: {integrity: sha512-g66Q2Kd9Uw3eRL7kkrTsGhi+eXxNoPDRFYH6z78sZQuYjPkUQgJDDMUYgBmaBsQx/fKMtemPrCj1ulGmyi0OSw==}
+    dependencies:
+      invariant: 2.2.4
     dev: false
 
   /@react-native/assets-registry@0.72.0:
@@ -9094,6 +9103,17 @@ packages:
       lodash: 4.17.21
       prop-types: 15.8.1
       react: 18.2.0
+      react-native: 0.72.6(@babel/core@7.23.2)(@babel/preset-env@7.23.2)(react@18.2.0)
+    dev: false
+
+  /react-native-modal-datetime-picker@17.1.0(@react-native-community/datetimepicker@7.6.1)(react-native@0.72.6):
+    resolution: {integrity: sha512-jfTwfaCLtBffYbQ+pOGFLM+J5HmUh3vb9rT0JrrQPjxzecdc8pNYreB1c96+mVuq8bDCvaCdIeuEsslTqLJL0Q==}
+    peerDependencies:
+      '@react-native-community/datetimepicker': '>=6.7.0'
+      react-native: '>=0.65.0'
+    dependencies:
+      '@react-native-community/datetimepicker': 7.6.1
+      prop-types: 15.8.1
       react-native: 0.72.6(@babel/core@7.23.2)(@babel/preset-env@7.23.2)(react@18.2.0)
     dev: false
 


### PR DESCRIPTION
### Description
Added a component for viewing activities (activities in the week) and a component for creating an activity. Also datepicker only works in light mode for IOS, https://github.com/mmazzarolo/react-native-modal-datetime-picker/issues/476 they force set the mode to light but I don't know if thats what you want so I left it blank

### Reason for Change
https://linear.app/uoftblueprint/issue/CFD-49/schedule-frontend-page 

Completes CFD-49

### Type of change
- [x] New feature (non-breaking change which adds functionality)

![IMG_5719](https://github.com/uoftblueprint/centre-for-dreams/assets/74844953/849bd1eb-5530-4408-a6ab-6e4e9e152903)
![IMG_5720](https://github.com/uoftblueprint/centre-for-dreams/assets/74844953/749a5e62-91a7-43a9-b9d5-f5e444e32b80)
![IMG_5721](https://github.com/uoftblueprint/centre-for-dreams/assets/74844953/e99a3877-1bb7-43d2-9e3b-412f5b9cfd52)

