### PR TITLE
[CFD-61] Endpoints to query users in our database

### DIFF
--- a/packages/api/src/root.ts
+++ b/packages/api/src/root.ts
@@ -4,6 +4,7 @@ import { announcementRouter } from "./router/announcement";
 import { developerRouter } from "./router/developer";
 import { discussionRouter } from "./router/discussion";
 import { notificationRouter } from "./router/notification";
+import { userRouter } from "./router/user";
 import { createTRPCRouter } from "./trpc";
 
 export const appRouter = createTRPCRouter({
@@ -13,6 +14,7 @@ export const appRouter = createTRPCRouter({
   activity: activityRouter,
   absence: absenceRouter,
   notification: notificationRouter,
+  user: userRouter,
 });
 
 // export type definition of API

--- a/packages/api/src/router/developer.ts
+++ b/packages/api/src/router/developer.ts
@@ -1,4 +1,4 @@
-import { createTRPCRouter, publicProcedure } from "../trpc";
+import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
 
 export const developerRouter = createTRPCRouter({
   count: publicProcedure
@@ -34,7 +34,7 @@ export const developerRouter = createTRPCRouter({
       upvotes: upvotes,
     };
   }),
-  ryanli_upvote: publicProcedure.mutation(async ({ ctx }) => {
+  ryanli_upvote: protectedProcedure.mutation(async ({ ctx }) => {
     return await ctx.db.developers.update({
       where: { name: "Ryan Li" },
       data: { upvotes: { increment: 1 } },

--- a/packages/api/src/router/user.ts
+++ b/packages/api/src/router/user.ts
@@ -1,19 +1,3 @@
-import { z } from "zod";
+import { createTRPCRouter } from "../trpc";
 
-import { createTRPCRouter, protectedProcedure } from "../trpc";
-
-export const userRouter = createTRPCRouter({
-  createIfNotExists: protectedProcedure
-    .input(z.string())
-    .query(async ({ ctx, input }) => {
-      await ctx.db.user.upsert({
-        where: {
-          clerkId: input,
-        },
-        update: {},
-        create: {
-          clerkId: input,
-        },
-      });
-    }),
-});
+export const userRouter = createTRPCRouter({});

--- a/packages/api/src/router/user.ts
+++ b/packages/api/src/router/user.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+
+export const userRouter = createTRPCRouter({
+  createIfNotExists: protectedProcedure
+    .input(z.string())
+    .query(async ({ ctx, input }) => {
+      await ctx.db.user.upsert({
+        where: {
+          clerkId: input,
+        },
+        update: {},
+        create: {
+          clerkId: input,
+        },
+      });
+    }),
+});

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -7,6 +7,7 @@
  * The pieces you will need to use are documented accordingly near the end
  */
 import { getAuth } from "@clerk/nextjs/server";
+import type { PrismaClient } from "@prisma/client";
 import { initTRPC, TRPCError } from "@trpc/server";
 import type * as trpcNext from "@trpc/server/adapters/next";
 import superjson from "superjson";
@@ -34,14 +35,21 @@ import { db } from "@cfd/db";
  * - trpc's `createSSGHelpers` where we don't have req/res
  * @see https://create.t3.gg/en/usage/trpc#-servertrpccontextts
  */
+interface innerTRPCContext {
+  db: PrismaClient;
+  auth: ReturnType<typeof getAuth>;
+  userId: number | null;
+}
+
 const createInnerTRPCContext = ({
   auth,
 }: {
   auth: ReturnType<typeof getAuth>;
-}) => {
+}): innerTRPCContext => {
   return {
     db,
     auth,
+    userId: null,
   };
 };
 
@@ -107,13 +115,27 @@ export const publicProcedure = t.procedure;
  *
  */
 
-const isAuthed = t.middleware(({ next, ctx }) => {
+const isAuthed = t.middleware(async ({ next, ctx }) => {
   if (!ctx.auth.userId) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
+
+  // If the user isn't in our database yet, insert them
+  const userId = ctx.auth.userId;
+  const user = await ctx.db.user.upsert({
+    where: {
+      clerkId: userId,
+    },
+    update: {},
+    create: {
+      clerkId: userId,
+    },
+  });
+
   return next({
     ctx: {
       auth: ctx.auth,
+      userId: user.id, // the user id within OUR database, a monotonically increasing integer
     },
   });
 });

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -38,7 +38,7 @@ import { db } from "@cfd/db";
 interface innerTRPCContext {
   db: PrismaClient;
   auth: ReturnType<typeof getAuth>;
-  userId: number | null;
+  userId: number | null; // the user id within OUR database, a monotonically increasing integer
 }
 
 const createInnerTRPCContext = ({

--- a/packages/db/prisma/migrations/20231111232813_add_clerk_id_to_user_table/migration.sql
+++ b/packages/db/prisma/migrations/20231111232813_add_clerk_id_to_user_table/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[clerkId]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `clerkId` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "clerkId" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_clerkId_key" ON "User"("clerkId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -14,6 +14,7 @@ datasource db {
 
 model User {
   id         Int         @id @default(autoincrement())
+  clerkId    String      @unique
   absences   Absence[]
   pushTokens PushToken[]
 }


### PR DESCRIPTION
### Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. --->

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->

<!--- Please delete options that are not relevant for linking your ticket. You likely only need one of these for your PR --->
Completes CFD-61

- Add clerkId to the users table, a unique field mapping users in our database to their clerkId
- When users are returned in the auth state, we also return their id within OUR database, which is a monotonically increasing integer
- If the user isn't present in the database, we insert them in there with their clerkId

### Type of change
<!--- Please delete options that are not relevant. --->

- [x] New feature (non-breaking change which adds functionality)

### Testing
<!--- Please describe the tests that you ran to verify your changes. This may be a screenshot of the change that you made. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration --->

Updated upvote for Ryan Li card on the home page to use protected procedure, which should create the corresponding user in the database if it did not exist before when the button is used.