### PR TITLE
[CFD-79] Create input box components

### DIFF
--- a/apps/expo/src/components/inputs/TextInput.tsx
+++ b/apps/expo/src/components/inputs/TextInput.tsx
@@ -8,7 +8,7 @@ export const TextInput: React.FC<CustomTextInputProps> & { RightElement: typeof 
     return (
         <View className="position-relative">
             <UnstyledTextInput
-                className="border border-p-40 rounded-[8px] p-[12px] font-body-lg leading-[0px] text-p-0"
+                className={`border border-p-40 rounded-[8px] p-[12px] font-body-lg leading-[0px] text-p-0 ${props.className}`}
                 placeholderTextColor={"#79767D"}
                 {...props}
             />

--- a/apps/expo/src/components/inputs/TextInput.tsx
+++ b/apps/expo/src/components/inputs/TextInput.tsx
@@ -8,14 +8,14 @@ export const TextInput: React.FC<CustomTextInputProps> & {
   RightElement: typeof RightElement;
 } = ({ children, ...props }) => {
   return (
-    <View className="position-relative">
+    <>
       <UnstyledTextInput
         className={`border-p-40 font-body-lg text-p-0 rounded-[8px] border p-[12px] leading-[0px] ${props.className}`}
         placeholderTextColor={"#79767D"}
         {...props}
       />
       {children}
-    </View>
+    </>
   );
 };
 

--- a/apps/expo/src/components/inputs/TextInput.tsx
+++ b/apps/expo/src/components/inputs/TextInput.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { TextInput as UnstyledTextInput } from 'react-native';
+import type { TextInputProps } from 'react-native';
+
+type CustomTextInputProps = TextInputProps
+
+const TextInput: React.FC<CustomTextInputProps> = (props) => {
+    return (
+        <UnstyledTextInput
+            className="border border-p-40 rounded-[8px] p-[12px] font-body-lg leading-[0px] text-p-0"
+            placeholderTextColor={"#79767D"}
+            {...props}
+        />
+    );
+};
+
+export default TextInput;

--- a/apps/expo/src/components/inputs/TextInput.tsx
+++ b/apps/expo/src/components/inputs/TextInput.tsx
@@ -1,17 +1,32 @@
 import React from 'react';
-import { TextInput as UnstyledTextInput } from 'react-native';
-import type { TextInputProps } from 'react-native';
+import { TextInput as UnstyledTextInput, View } from 'react-native';
+import type { TextInputProps, ViewProps } from 'react-native';
 
 type CustomTextInputProps = TextInputProps
 
-const TextInput: React.FC<CustomTextInputProps> = (props) => {
+export const TextInput: React.FC<CustomTextInputProps> & { RightElement: typeof RightElement } = ({ children, ...props }) => {
     return (
-        <UnstyledTextInput
-            className="border border-p-40 rounded-[8px] p-[12px] font-body-lg leading-[0px] text-p-0"
-            placeholderTextColor={"#79767D"}
-            {...props}
-        />
+        <View className="position-relative">
+            <UnstyledTextInput
+                className="border border-p-40 rounded-[8px] p-[12px] font-body-lg leading-[0px] text-p-0"
+                placeholderTextColor={"#79767D"}
+                {...props}
+            />
+            {children}
+        </View>
     );
 };
 
-export default TextInput;
+interface RightElementProps extends ViewProps {
+    children: React.ReactNode;
+}
+
+const RightElement: React.FC<RightElementProps> = ({ children, ...props }) => {
+    return (
+        <View className="absolute right-[12px] top-[8px]" {...props}>
+            {children}
+        </View>
+    );
+}
+
+TextInput.RightElement = RightElement;

--- a/apps/expo/src/components/inputs/TextInput.tsx
+++ b/apps/expo/src/components/inputs/TextInput.tsx
@@ -1,32 +1,34 @@
-import React from 'react';
-import { TextInput as UnstyledTextInput, View } from 'react-native';
-import type { TextInputProps, ViewProps } from 'react-native';
+import React from "react";
+import { TextInput as UnstyledTextInput, View } from "react-native";
+import type { TextInputProps, ViewProps } from "react-native";
 
-type CustomTextInputProps = TextInputProps
+type CustomTextInputProps = TextInputProps;
 
-export const TextInput: React.FC<CustomTextInputProps> & { RightElement: typeof RightElement } = ({ children, ...props }) => {
-    return (
-        <View className="position-relative">
-            <UnstyledTextInput
-                className={`border border-p-40 rounded-[8px] p-[12px] font-body-lg leading-[0px] text-p-0 ${props.className}`}
-                placeholderTextColor={"#79767D"}
-                {...props}
-            />
-            {children}
-        </View>
-    );
+export const TextInput: React.FC<CustomTextInputProps> & {
+  RightElement: typeof RightElement;
+} = ({ children, ...props }) => {
+  return (
+    <View className="position-relative">
+      <UnstyledTextInput
+        className={`border-p-40 font-body-lg text-p-0 rounded-[8px] border p-[12px] leading-[0px] ${props.className}`}
+        placeholderTextColor={"#79767D"}
+        {...props}
+      />
+      {children}
+    </View>
+  );
 };
 
 interface RightElementProps extends ViewProps {
-    children: React.ReactNode;
+  children: React.ReactNode;
 }
 
 const RightElement: React.FC<RightElementProps> = ({ children, ...props }) => {
-    return (
-        <View className="absolute right-[12px] top-[8px]" {...props}>
-            {children}
-        </View>
-    );
-}
+  return (
+    <View className="absolute right-[12px] top-[8px]" {...props}>
+      {children}
+    </View>
+  );
+};
 
 TextInput.RightElement = RightElement;

--- a/apps/expo/src/components/inputs/index.ts
+++ b/apps/expo/src/components/inputs/index.ts
@@ -1,0 +1,3 @@
+import { TextInput } from "./TextInput";
+
+export { TextInput };


### PR DESCRIPTION
### Description
Adds a flexible and customizable text input component based on React Native's `TextInput`

### Reason for Change

Completes CFD-79



### Type of change
<!--- Please delete options that are not relevant. --->


- [x] New feature (non-breaking change which adds functionality)


### Testing
<!--- Please describe the tests that you ran to verify your changes. This may be a screenshot of the change that you made. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration --->

Tested single-line input, multiline input, different input modes (email, numeric, password, etc.).

Example code:

```typescript
import Ionicons from "@expo/vector-icons/Ionicons";
import { TextInput } from "~/components/inputs";

<TextInput
    placeholder="Write description here..."
    multiline
    className="my-2 h-[168px]"
/>
<View>
  <TextInput placeholder="Search" inputMode="numeric" multiline>
      <TextInput.RightElement>
          <Ionicons
              name="search"
              size={24}
              color="black"
              onPress={() => alert("hi there")}
          />
      </TextInput.RightElement>
  </TextInput>
</View>
<TextInput
    placeholder="Enter email"
    multiline
    className="my-2"
    inputMode="email"
/>
```
<img src="https://github.com/uoftblueprint/centre-for-dreams/assets/40612523/6352a1b5-e415-4bdb-8b06-715df96f4953" width="300px"/>
