### PR TITLE
[CFD-119] Fixed nav bar sizing

### DIFF
--- a/apps/expo/src/components/NavBar.tsx
+++ b/apps/expo/src/components/NavBar.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from "react";
 import React from "react";
-import { View } from "react-native";
+import { Text, View } from "react-native";
 import { Tabs } from "expo-router";
 
 import CalendarFocused from "../../assets/calendar-white.svg";
@@ -22,34 +22,42 @@ const icons: Record<string, ReactElement[]> = {
   account: [<Account key="normal" />, <AccountFocused key="focused" />],
 };
 
+const labels: Record<string, string> = {
+  "calendar/index": "Calendar",
+  notices: "Notices",
+  forum: "Forum",
+  account: "Account",
+};
+
 const NavBar = () => {
   return (
     <Tabs
       screenOptions={({ route }) => ({
         headerShown: false,
         tabBarStyle: {
-          height: "10%",
+          height: "11%",
           width: "100%",
           borderTopLeftRadius: 20,
           borderTopRightRadius: 20,
           backgroundColor: "#D5DBE9",
           position: "absolute",
         },
-        tabBarLabelStyle: {
-          fontFamily: "Poppins_500Medium",
-          fontSize: 14,
-          color: "#2E4D90",
-          top: 10,
-        },
+        tabBarShowLabel: false,
         tabBarIcon: ({ focused }) => (
-          <View
-            className={`top-2 h-9 w-[68px] flex-1 items-center justify-center ${
-              focused ? "bg-p-40 rounded-[22px]" : ""
-            }`}
-          >
-            <View className="h-9 w-9 items-center justify-center">
-              {focused ? icons[route.name]![1] : icons[route.name]![0]}
+          <View className="h-full items-center justify-center">
+            <View
+              className={`mt-1.5 h-10 w-16 items-center justify-center pb-0 ${
+                focused ? "bg-p-40 rounded-full" : ""
+              }`}
+            >
+              <View className="h-9 w-9 items-center justify-center">
+                {focused ? icons[route.name]![1] : icons[route.name]![0]}
+              </View>
             </View>
+
+            <Text className="text-p-40 font-label-lg mt-0.5 ">
+              {labels[route.name]!}
+            </Text>
           </View>
         ),
       })}
@@ -65,28 +73,24 @@ const NavBar = () => {
         name="calendar/index"
         options={{
           href: "/calendar/",
-          tabBarLabel: "Calendar",
         }}
       />
       <Tabs.Screen
         name="notices"
         options={{
           href: "/notices",
-          tabBarLabel: "Notices",
         }}
       />
       <Tabs.Screen
         name="forum"
         options={{
           href: "/forum",
-          tabBarLabel: "Forum",
         }}
       />
       <Tabs.Screen
         name="account"
         options={{
           href: "/account",
-          tabBarLabel: "Account",
         }}
       />
       <Tabs.Screen


### PR DESCRIPTION
### Description
Fixed navbar sizing to work with different screen sizes.

_Note:_ I made the tab bar label inside the tab bar icon slot, instead of on its own. It is much easier to align everything and move everything together that way. Otherwise there was some weird sizing things. But I can change it back if you want.

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->

<!--- Please delete options that are not relevant for linking your ticket. You likely only need one of these for your PR --->
Completes CFD-119

### Type of change
<!--- Please delete options that are not relevant. --->
- [X] Bug fix (non-breaking change which fixes an issue)

### Testing
<!--- Please describe the tests that you ran to verify your changes. This may be a screenshot of the change that you made. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration --->
<img width="359" alt="Screenshot 2024-03-10 at 12 51 24 AM" src="https://github.com/uoftblueprint/centre-for-dreams/assets/113125436/63724a25-4c35-45d2-bcc5-6a02126bb4af">


I tried to minimize the space at the bottom as much as i could...
<img width="346" alt="Screenshot 2024-03-10 at 12 59 38 AM" src="https://github.com/uoftblueprint/centre-for-dreams/assets/113125436/dee4429e-7f0e-4401-a996-52d5f1aa917f">

