### PR TITLE
CFD131: Deny login if user not approved

### DIFF
--- a/apps/expo/src/app/signin.tsx
+++ b/apps/expo/src/app/signin.tsx
@@ -6,7 +6,6 @@ import { SignedOut, useSignIn } from "@clerk/clerk-expo";
 
 import FilledButton from "~/components/FilledButtons";
 import { TextInput } from "~/components/inputs";
-import { api } from "~/utils/api";
 import { getErrorMessage } from "~/utils/errorUtils";
 import Logo from "../../assets/logo.png";
 
@@ -14,51 +13,28 @@ const SignInScreen = () => {
   const router = useRouter();
   const { signIn, isLoaded } = useSignIn();
   const [emailAddress, setEmailAddress] = useState("");
-  const [approvalError, setApprovalError] = useState("");
-  const { refetch } = api.user.isEmailApproved.useQuery(emailAddress, {
-    refetchOnWindowFocus: false,
-    enabled: false,
-  });
 
   /**
    * Sends a one-time passcode to the email provided and redirects users to the next page to
    * authenticate with the code. If there is an error, the user will not be redirected,
    * and a toast will be displayed showing the error.
    */
-  const getEmailCode = async () => {
+  const getEmailCode = () => {
     if (!isLoaded) {
       return;
     }
 
-    const res = (await refetch()).data;
-    // If we're in development mode and the email address is blanked,
-    // do not validate. This allows developers to login by clicking with a
-    // blank email address
-    if (!(__DEV__ && emailAddress === "")) {
-      if (!res?.userExists) {
-        setApprovalError(
-          "*Account with the corresponding email does not exist*",
-        );
-        return;
-      }
-      if (!res?.isApproved) {
-        setApprovalError("*Your account hasn’t been activated*");
-        return;
-      }
-    }
+    const isDevModeUsingTestEmail = __DEV__ && emailAddress === "";
 
     signIn
       .create({
         identifier:
-          __DEV__ &&
-          emailAddress === "" &&
-          process.env.EXPO_PUBLIC_CLERK_TEST_EMAIL
+          isDevModeUsingTestEmail && process.env.EXPO_PUBLIC_CLERK_TEST_EMAIL
             ? process.env.EXPO_PUBLIC_CLERK_TEST_EMAIL
             : emailAddress,
         strategy: "email_code",
       })
       .then(() => {
-        setApprovalError("");
         router.push("/signincode");
       })
       .catch((err: unknown) => {
@@ -86,7 +62,6 @@ const SignInScreen = () => {
               onChangeText={(emailAddress) => setEmailAddress(emailAddress)}
               aria-label="input"
             />
-            <Text className="text-rose-700">{approvalError}</Text>
           </View>
         </View>
         <View className="flex flex-1 flex-col items-center justify-start">

--- a/apps/expo/src/app/signin.tsx
+++ b/apps/expo/src/app/signin.tsx
@@ -6,6 +6,7 @@ import { SignedOut, useSignIn } from "@clerk/clerk-expo";
 
 import FilledButton from "~/components/FilledButtons";
 import { TextInput } from "~/components/inputs";
+import { api } from "~/utils/api";
 import { getErrorMessage } from "~/utils/errorUtils";
 import Logo from "../../assets/logo.png";
 
@@ -13,16 +14,39 @@ const SignInScreen = () => {
   const router = useRouter();
   const { signIn, isLoaded } = useSignIn();
   const [emailAddress, setEmailAddress] = useState("");
+  const [approvalError, setApprovalError] = useState("");
+  const { refetch } = api.user.isEmailApproved.useQuery(emailAddress, {
+    refetchOnWindowFocus: false,
+    enabled: false,
+  });
 
   /**
    * Sends a one-time passcode to the email provided and redirects users to the next page to
    * authenticate with the code. If there is an error, the user will not be redirected,
    * and a toast will be displayed showing the error.
    */
-  const getEmailCode = () => {
+  const getEmailCode = async () => {
     if (!isLoaded) {
       return;
     }
+
+    const res = (await refetch()).data;
+    // If we're in development mode and the email address is blanked,
+    // do not validate. This allows developers to login by clicking with a
+    // blank email address
+    if (!(__DEV__ && emailAddress === "")) {
+      if (!res?.userExists) {
+        setApprovalError(
+          "*Account with the corresponding email does not exist*",
+        );
+        return;
+      }
+      if (!res?.isApproved) {
+        setApprovalError("*Your account hasn’t been activated*");
+        return;
+      }
+    }
+
     signIn
       .create({
         identifier:
@@ -34,6 +58,7 @@ const SignInScreen = () => {
         strategy: "email_code",
       })
       .then(() => {
+        setApprovalError("");
         router.push("/signincode");
       })
       .catch((err: unknown) => {
@@ -61,6 +86,7 @@ const SignInScreen = () => {
               onChangeText={(emailAddress) => setEmailAddress(emailAddress)}
               aria-label="input"
             />
+            <Text className="text-rose-700">{approvalError}</Text>
           </View>
         </View>
         <View className="flex flex-1 flex-col items-center justify-start">

--- a/apps/expo/src/app/signincode.tsx
+++ b/apps/expo/src/app/signincode.tsx
@@ -2,18 +2,22 @@ import { useState } from "react";
 import { Image, Text, View } from "react-native";
 import Toast from "react-native-root-toast";
 import { useRouter } from "expo-router";
-import { SignedOut, useSignIn } from "@clerk/clerk-expo";
+import { useAuth, useSignIn } from "@clerk/clerk-expo";
 
 import FilledButton from "~/components/FilledButtons";
 import { TextInput } from "~/components/inputs";
+import { api } from "~/utils/api";
 import { getErrorMessage } from "~/utils/errorUtils";
 import Logo from "../../assets/logo.png";
 
 const SignInScreen = () => {
   const router = useRouter();
   const { signIn, setActive, isLoaded } = useSignIn();
-
+  const { signOut } = useAuth();
   const [code, setCode] = useState("");
+  const [approvalError, setApprovalError] = useState("");
+  const createUserWithClerkIdIfNotExists =
+    api.user.createUserWithClerkIdIfNotExists.useMutation();
 
   /**
    * Attempts to log the user in with the one-time passcode provided. The email used is the one provided in the
@@ -24,16 +28,35 @@ const SignInScreen = () => {
       return;
     }
 
+    const isDevModeUsingTestEmail = __DEV__ && code === "";
+
     try {
       const completeSignIn = await signIn.attemptFirstFactor({
         strategy: "email_code",
         code:
-          __DEV__ && code === "" && process.env.EXPO_PUBLIC_CLERK_TEST_CODE
+          isDevModeUsingTestEmail && process.env.EXPO_PUBLIC_CLERK_TEST_CODE
             ? process.env.EXPO_PUBLIC_CLERK_TEST_CODE
             : code,
       });
-      await setActive({ session: completeSignIn.createdSessionId });
-      router.replace("/account");
+
+      // If we have the id, that means the user successfully
+      // authenticated using Clerk. However we shouldn't update the
+      // active session just yet in case they're not approved
+      if (completeSignIn.id) {
+        const isApproved = await createUserWithClerkIdIfNotExists.mutateAsync(
+          completeSignIn.id,
+        );
+        if (isApproved || isDevModeUsingTestEmail) {
+          await setActive({ session: completeSignIn.createdSessionId });
+          router.replace("/calendar/");
+          return;
+        }
+      }
+
+      // Sign out of the session to allow the user to restart the
+      // signin flow once again if they choose to go back
+      await signOut();
+      setApprovalError("*Your account hasn’t been activated*");
     } catch (err) {
       const errorMessage = `Error signing in: ${getErrorMessage(err)}`;
       Toast.show(errorMessage, {
@@ -43,36 +66,40 @@ const SignInScreen = () => {
   };
 
   return (
-    <SignedOut>
-      <View className="flex h-full p-4">
-        <View className="flex-1 items-center justify-center ">
-          <Image source={Logo} className="w-3/5" resizeMode="contain" />
+    <View className="flex h-full p-4">
+      <View className="flex-1 items-center justify-center ">
+        <Image source={Logo} className="w-3/5" resizeMode="contain" />
+      </View>
+      <View className="flex-1 justify-center">
+        <View className="gap-2">
+          <Text aria-label="Label for Verfication Code">Code</Text>
+          <TextInput
+            autoCapitalize="none"
+            value={code}
+            placeholder="Verification Code"
+            className="w-100 rounded-lg border p-2"
+            onChangeText={(code) => setCode(code)}
+            aria-label="input"
+          />
         </View>
-        <View className="flex-1 justify-center">
-          <View className="gap-2">
-            <Text aria-label="Label for Verfication Code">Code</Text>
-            <TextInput
-              autoCapitalize="none"
-              value={code}
-              placeholder="Verification Code"
-              className="w-100 rounded-lg border p-2"
-              onChangeText={(code) => setCode(code)}
-              aria-label="input"
-            />
-          </View>
+        <Text className="text-rose-700">{approvalError}</Text>
+      </View>
+      <View className="flex flex-1 flex-row items-start justify-center gap-x-5">
+        <View className="w-30">
+          <FilledButton
+            onClick={async () => {
+              await signOut();
+              router.replace("/signin");
+            }}
+          >
+            Back
+          </FilledButton>
         </View>
-        <View className="flex flex-1 flex-row items-start justify-center gap-x-5">
-          <View className="w-30">
-            <FilledButton onClick={() => router.replace("/signin")}>
-              Back
-            </FilledButton>
-          </View>
-          <View className="w-30">
-            <FilledButton onClick={onSignInPress}>Sign In</FilledButton>
-          </View>
+        <View className="w-30">
+          <FilledButton onClick={onSignInPress}>Sign In</FilledButton>
         </View>
       </View>
-    </SignedOut>
+    </View>
   );
 };
 

--- a/packages/db/prisma/migrations/20240403005604_create_is_approved_field/migration.sql
+++ b/packages/db/prisma/migrations/20240403005604_create_is_approved_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "isApproved" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -15,6 +15,7 @@ datasource db {
 model User {
   id            Int         @id @default(autoincrement())
   clerkId       String      @unique
+  isApproved    Boolean     @default(false)
   participant   Participant @relation(fields: [participantId], references: [id])
   participantId Int         @unique
   pushTokens    PushToken[]


### PR DESCRIPTION
### Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. --->

If the user's email is not marked `isApproved` in clerk, they will not be able to proceed to the login code page. There will be 2 separate error messages displayed below the input box for
- User email is in clerk, but not approved
- User email is not in clerk

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->

This is to follow the design in figma and also prevent unapproved users from logging in

<!--- Please delete options that are not relevant for linking your ticket. You likely only need one of these for your PR --->
Completes CFD-131


### Type of change
<!--- Please delete options that are not relevant. --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing
<!--- Please describe the tests that you ran to verify your changes. This may be a screenshot of the change that you made. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration --->

Source: trust me bro