### PR TITLE
CFD-133: Fix auth middleware participant unique key constraint

### DIFF
--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -131,16 +131,14 @@ const isAuthed = t.middleware(async ({ next, ctx }) => {
   // If the user isn't in our database yet, insert them
   // Also creating a new participant that's linked to them
   if (user == null) {
-    const participant = await ctx.db.participant.create({
-      data: {
-        name: "",
-      },
-    });
-
     user = await ctx.db.user.create({
       data: {
         clerkId: clerkId,
-        participantId: participant.id,
+        participant: {
+          create: {
+            name: "",
+          },
+        },
       },
     });
   }


### PR DESCRIPTION
### Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. --->

This PR fixes the issue where paticipant IDs will be re-used when logging in with another account since it was hard coded to `1`. This PR will change to create a new unique participant object without hard coding the ID and linking it to the user.

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->
`protectedProcedure` was unable to be used since it inserted the user into the database if they didn't exist on each run. This means that if the user logged in with a different account the insertion would fail because the participant id would clash.

<!--- Please delete options that are not relevant for linking your ticket. You likely only need one of these for your PR --->
Fixes CFD-63

Completes CFD-133

### Type of change
<!--- Please delete options that are not relevant. --->

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing
<!--- Please describe the tests that you ran to verify your changes. This may be a screenshot of the change that you made. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration --->

Source: trust me bro
