### PR TITLE
Invalidate Expo Query Cache on Mutation

### DIFF
--- a/apps/expo/src/utils/api.tsx
+++ b/apps/expo/src/utils/api.tsx
@@ -11,7 +11,16 @@ import type { AppRouter } from "@cfd/api";
 /**
  * A set of typesafe hooks for consuming your API.
  */
-export const api = createTRPCReact<AppRouter>();
+export const api = createTRPCReact<AppRouter>({
+  overrides: {
+    useMutation: {
+      async onSuccess(opts) {
+        await opts.originalFn();
+        await opts.queryClient.invalidateQueries();
+      },
+    },
+  },
+});
 export { type RouterInputs, type RouterOutputs } from "@cfd/api";
 
 /**


### PR DESCRIPTION
### Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. --->
Invalidates query cache whenever a mutation is made.

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->
This is the behavior currently used for the Nextjs client, but was not added to the Expo app.

### Type of change
<!--- Please delete options that are not relevant. --->

- [x] Bug fix (non-breaking change which fixes an issue)