### PR TITLE
Solarescarlos101/cfd 153 create api endpoint to fetch subactivities for events

### DIFF
--- a/packages/api/src/router/activity.ts
+++ b/packages/api/src/router/activity.ts
@@ -76,4 +76,16 @@ export const activityRouter = createTRPCRouter({
         },
       });
     }),
+  getSubactivities: protectedProcedure // protectedProcedure because logged-in users should be able to use this
+    .input(z.object({ activityId: z.number() })) // I assumed "event" and "activity" are used interchangeably in the ticket
+    .query(async ({ ctx, input }) => {
+      return await ctx.db.activity.findUnique({
+        where: {
+          id: input.activityId,
+        },
+        select: {
+          subactivities: true,
+        },
+      });
+    }),  
 });

--- a/packages/api/src/router/activity.ts
+++ b/packages/api/src/router/activity.ts
@@ -93,8 +93,6 @@ export const activityRouter = createTRPCRouter({
         },
       });
 
-      console.log("Query result:", result);
-
       return result;
     }),
 });

--- a/packages/api/src/router/activity.ts
+++ b/packages/api/src/router/activity.ts
@@ -1,12 +1,7 @@
 import { addWeeks } from "date-fns";
 import { z } from "zod";
 
-import {
-  adminProcedure,
-  createTRPCRouter,
-  protectedProcedure,
-  publicProcedure,
-} from "../trpc";
+import { adminProcedure, createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const activityRouter = createTRPCRouter({
   getSchedule: protectedProcedure
@@ -81,7 +76,7 @@ export const activityRouter = createTRPCRouter({
         },
       });
     }),
-  getSubactivities: publicProcedure
+  getSubactivities: protectedProcedure
     .input(z.object({ id: z.number() })) // I assumed "event" and "activity" are used interchangeably in the ticket
     .query(async ({ ctx, input }) => {
       const result = await ctx.db.activity.findUnique({

--- a/packages/api/src/router/activity.ts
+++ b/packages/api/src/router/activity.ts
@@ -84,8 +84,6 @@ export const activityRouter = createTRPCRouter({
   getSubactivities: publicProcedure
     .input(z.object({ id: z.number() })) // I assumed "event" and "activity" are used interchangeably in the ticket
     .query(async ({ ctx, input }) => {
-      console.log("Received input:", input);
-
       const result = await ctx.db.activity.findUnique({
         where: {
           id: input.id,

--- a/packages/api/src/router/activity.ts
+++ b/packages/api/src/router/activity.ts
@@ -1,7 +1,7 @@
 import { addWeeks } from "date-fns";
 import { z } from "zod";
 
-import { adminProcedure, createTRPCRouter, protectedProcedure } from "../trpc";
+import { adminProcedure, createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
 
 export const activityRouter = createTRPCRouter({
   getSchedule: protectedProcedure
@@ -76,16 +76,23 @@ export const activityRouter = createTRPCRouter({
         },
       });
     }),
-  getSubactivities: protectedProcedure // protectedProcedure because logged-in users should be able to use this
-    .input(z.object({ activityId: z.number() })) // I assumed "event" and "activity" are used interchangeably in the ticket
+  getSubactivities: publicProcedure
+    .input(z.object({ id: z.number() })) // I assumed "event" and "activity" are used interchangeably in the ticket
     .query(async ({ ctx, input }) => {
-      return await ctx.db.activity.findUnique({
+      console.log("Received input:", input);
+
+      const result = await ctx.db.activity.findUnique({
         where: {
-          id: input.activityId,
+          id: input.id,
         },
         select: {
           subactivities: true,
         },
       });
+  
+      console.log("Query result:", result);
+  
+      return result;
+
     }),  
 });

--- a/packages/api/src/router/activity.ts
+++ b/packages/api/src/router/activity.ts
@@ -1,7 +1,12 @@
 import { addWeeks } from "date-fns";
 import { z } from "zod";
 
-import { adminProcedure, createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
+import {
+  adminProcedure,
+  createTRPCRouter,
+  protectedProcedure,
+  publicProcedure,
+} from "../trpc";
 
 export const activityRouter = createTRPCRouter({
   getSchedule: protectedProcedure
@@ -89,10 +94,9 @@ export const activityRouter = createTRPCRouter({
           subactivities: true,
         },
       });
-  
-      console.log("Query result:", result);
-  
-      return result;
 
-    }),  
+      console.log("Query result:", result);
+
+      return result;
+    }),
 });


### PR DESCRIPTION
### Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. --->

Created the getSubactivities endpoint in packages/api/src/router/activity.ts as described in https://linear.app/uoftblueprint/issue/CFD-153/create-api-endpoint-to-fetch-subactivities-for-events.
When given an activity id, it returns all subactivities in that activity. Included some console logs.

### Reason for Change
<!--- Why is this change being made? By default, just provide the Linear ticket ID. You may add extra context if you made changes that were not specified in the ticket. --->
https://linear.app/uoftblueprint/issue/CFD-153/create-api-endpoint-to-fetch-subactivities-for-events

<!--- Please delete options that are not relevant for linking your ticket. You likely only need one of these for your PR --->
Completes CFD ticket https://linear.app/uoftblueprint/issue/CFD-153/create-api-endpoint-to-fetch-subactivities-for-events

### Type of change
<!--- Please delete options that are not relevant. --->

- [X] New feature (non-breaking change which adds functionality)

### Testing
<!--- Please describe the tests that you ran to verify your changes. This may be a screenshot of the change that you made. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration --->

- First I added some console log statements within the endpoint. Then, I ran pnpm dev and created a new activity with its own subactivity. I then navigated to the tRPC panel (http://localhost:3000/api/panel) and called getSubactivities under the activity router. I used id 100 (use the id of the activity you created).
![Screenshot (115)](https://github.com/user-attachments/assets/d0b0bd27-dcbc-4225-b804-c2f1559ec459)

